### PR TITLE
Switch Jenkins authentication to OpenShift OAuth

### DIFF
--- a/app-of-apps.yaml
+++ b/app-of-apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: gitops-resources
   source:
     path: ./app-of-apps
-    repoURL: https://github.com/redhat-appstudio/rhtap-services-gitops
+    repoURL: https://github.com/redhat-appstudio/rhtap-services-gitops.git
     targetRevision: main
   syncPolicy:
     automated:

--- a/app-of-apps/jenkins.yaml
+++ b/app-of-apps/jenkins.yaml
@@ -14,7 +14,7 @@ spec:
       path: "components/jenkins"
     - repoURL: https://charts.jenkins.io
       chart: jenkins
-      targetRevision: 5.8.73 # Use a specific chart version
+      targetRevision: 5.8.104 # Use a specific chart version
       helm:
         releaseName: jenkins
         valueFiles:

--- a/components/jenkins/agent/Dockerfile
+++ b/components/jenkins/agent/Dockerfile
@@ -185,6 +185,10 @@ RUN echo "=== Verifying binary locations ===" && \
     which python3 && \
     echo "=== All binary locations verified ==="
 
+# Copy jenkins-agent entrypoint script
+COPY jenkins-agent /usr/local/bin/jenkins-agent
+RUN chmod +x /usr/local/bin/jenkins-agent
+
 # Switch to jenkins user
 USER ${user}
 
@@ -214,6 +218,6 @@ LABEL \
     org.label-schema.vendor="Custom Jenkins Agent" \
     org.label-schema.schema-version="1.0"
 
-# For agent injection, the container needs to stay running
-# Jenkins will inject the agent process into this container
-CMD ["sleep", "infinity"]
+# Use the official Jenkins agent entrypoint script
+# This allows using args: ['$(JENKINS_SECRET)', '$(JENKINS_NAME)'] in pod templates
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/components/jenkins/agent/jenkins-agent
+++ b/components/jenkins/agent/jenkins-agent
@@ -1,0 +1,141 @@
+#!/usr/bin/env sh
+
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+# Usage jenkins-agent.sh [options] -url http://jenkins -secret [SECRET] -name [AGENT_NAME]
+# Optional environment variables :
+# * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
+# * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
+# * JENKINS_AGENT_FILE : Jenkins agent jar file location, /usr/share/jenkins/agent.jar will be used if this is not set
+# * REMOTING_OPTS : Generic way to pass additional CLI options to agent.jar (see -help)
+#
+# Deprecated environment variables (prefer setting REMOTING_OPTS)
+# * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
+# * JENKINS_URL : alternate jenkins URL
+# * JENKINS_SECRET : agent secret, if not set as an argument
+# * JENKINS_AGENT_NAME : agent name, if not set as an argument
+# * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
+# * JENKINS_WEB_SOCKET: true if the connection should be made via WebSocket rather than TCP
+# * JENKINS_DIRECT_CONNECTION: Connect directly to this TCP agent port, skipping the HTTP(S) connection parameter download.
+#                              Value: "<HOST>:<PORT>"
+# * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins controller. When this is set,
+#                              the agent skips connecting to an HTTP(S) port for connection info.
+# * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
+
+if [ $# -eq 1 ] && [ "${1#-}" = "$1" ] ; then
+
+	# if `docker run` only has one arguments and it is not an option as `-help`, we assume user is running alternate command like `bash` to inspect the image
+	exec "$@"
+
+else
+
+	# if -tunnel is not provided, try env vars
+	case "$@" in
+		*"-tunnel "*) ;;
+		*)
+		if [ ! -z "$JENKINS_TUNNEL" ]; then
+			TUNNEL="-tunnel $JENKINS_TUNNEL"
+		fi ;;
+	esac
+
+	# if -workDir is not provided, try env vars
+	if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
+		case "$@" in
+			*"-workDir"*) echo "Warning: Work directory is defined twice in command-line arguments and the environment variable" ;;
+			*)
+			WORKDIR="-workDir $JENKINS_AGENT_WORKDIR" ;;
+		esac
+	fi
+
+	if [ -n "$JENKINS_URL" ]; then
+		URL="-url $JENKINS_URL"
+	fi
+
+	if [ -n "$JENKINS_NAME" ]; then
+		JENKINS_AGENT_NAME="$JENKINS_NAME"
+	fi
+
+	if [ "$JENKINS_WEB_SOCKET" = true ]; then
+		WEB_SOCKET=-webSocket
+	fi
+
+	if [ -n "$JENKINS_PROTOCOLS" ]; then
+		PROTOCOLS="-protocols $JENKINS_PROTOCOLS"
+	fi
+
+	if [ -n "$JENKINS_DIRECT_CONNECTION" ]; then
+		DIRECT="-direct $JENKINS_DIRECT_CONNECTION"
+	fi
+
+	if [ -n "$JENKINS_INSTANCE_IDENTITY" ]; then
+		INSTANCE_IDENTITY="-instanceIdentity $JENKINS_INSTANCE_IDENTITY"
+	fi
+
+	if [ "$JENKINS_JAVA_BIN" ]; then
+		JAVA_BIN="$JENKINS_JAVA_BIN"
+	else
+		# if java home is defined, use it
+		JAVA_BIN="java"
+		if [ "$JAVA_HOME" ]; then
+			JAVA_BIN="$JAVA_HOME/bin/java"
+		fi
+	fi
+
+	if [ "$JENKINS_JAVA_OPTS" ]; then
+		JAVA_OPTIONS="$JENKINS_JAVA_OPTS"
+	else
+		# if JAVA_OPTS is defined, use it
+		if [ "$JAVA_OPTS" ]; then
+			JAVA_OPTIONS="$JAVA_OPTS"
+		fi
+	fi
+
+	if [ "$JENKINS_AGENT_FILE" ]; then
+		AGENT_FILE="$JENKINS_AGENT_FILE"
+	else
+		AGENT_FILE="/usr/share/jenkins/agent.jar"
+	fi
+
+	# if both required options are defined, do not pass the parameters
+	if [ -n "$JENKINS_SECRET" ]; then
+		case "$@" in
+			*"${JENKINS_SECRET}"*) echo "Warning: SECRET is defined twice in command-line arguments and the environment variable" ;;
+			*)
+			SECRET="-secret ${JENKINS_SECRET}" ;;
+		esac
+	fi
+
+	if [ -n "$JENKINS_AGENT_NAME" ]; then
+		case "$@" in
+			*"${JENKINS_AGENT_NAME}"*) echo "Warning: AGENT_NAME is defined twice in command-line arguments and the environment variable" ;;
+			*)
+			AGENT_NAME="-name ${JENKINS_AGENT_NAME}" ;;
+		esac
+	fi
+
+	#TODO: Handle the case when the command-line and Environment variable contain different values.
+	#It is fine it blows up for now since it should lead to an error anyway.
+
+        exec $JAVA_BIN $JAVA_OPTIONS -jar $AGENT_FILE $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $REMOTING_OPTS "$@"
+
+fi

--- a/components/jenkins/values.yaml
+++ b/components/jenkins/values.yaml
@@ -19,22 +19,42 @@ controller:
   # -- Custom Pod labels (an object with `label-key: label-value` pairs)
   podLabels:
     tssc-jenkins-agent: true
+  # -- Additional Java options for Jenkins controller
+  javaOpts: >-
+    -Dhudson.model.User.allowNonExistentUserToLogin=false
+  # Enable OpenShift OAuth
+  containerEnv:
+    - name: OPENSHIFT_ENABLE_OAUTH
+      value: "true"
+    - name: OPENSHIFT_PERMISSIONS_POLL_INTERVAL
+      value: "300000"
   JCasC:
-    defaultConfig: true
+    defaultConfig: false
     configScripts:
-      jenkins-system: |
+      jenkins-config: |
         jenkins:
-          systemMessage: "Jenkins configured with Configuration as Code for RHTAP on OpenShift"
-          securityRealm:
-            local:
-              allowsSignup: false
-              users:
-                - id: "admin"
-                  name: "Jenkins Admin"
-                  password: "${chart-admin-password}"
           authorizationStrategy:
-            loggedInUsersCanDoAnything:
-              allowAnonymousRead: false
+            globalMatrix:
+              entries:
+                - group:
+                    name: "authenticated"
+                    permissions:
+                      - "Overall/Read"
+          disableRememberMe: true
+          mode: NORMAL
+          numExecutors: 0
+          labelString: ""
+          markupFormatter:
+            plainText
+          slaveAgentPort: 50000
+          crumbIssuer:
+            standard:
+              excludeClientIPFromCrumb: true
+        security:
+          apiToken:
+            creationOfLegacyTokenEnabled: false
+            tokenGenerationOnCreationEnabled: false
+            usageStatisticsEnabled: true
   serviceType: ClusterIP
   servicePort: 8080
   # OpenShift 4.18 uses restricted-v2 SCC by default. To allow the init container to write to the
@@ -45,8 +65,6 @@ controller:
     fsGroup: 1000
   containerSecurityContext: {}
   installPlugins:
-    - openshift-client
-    - openshift-login
     - gitlab-plugin
     - github
     - bitbucket
@@ -55,6 +73,8 @@ controller:
     - git
     - configuration-as-code
     - job-dsl:latest
+    - matrix-auth
+    - openshift-login
   # Openshift route
   route:
     # -- Enables openshift route
@@ -79,6 +99,8 @@ rbac:
   serviceAccount:
     create: true
     name: "jenkins"
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.jenkins: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"jenkins"}}'
 
 agent:
   # -- Enable Kubernetes plugin jnlp-agent podTemplate
@@ -118,65 +140,35 @@ agent:
         label: tssc-jenkins-agent
         serviceAccount: jenkins
         namespace: jenkins
-        idleMinutes: 0
+        idleMinutes: 4
         podRetention: Never
         nodeUsageMode: NORMAL
-        yaml: |
-          spec:
-            initContainers:
-            - name: agent-injector
-              image: jenkins/inbound-agent:3341.v0766d82b_dec0-1
-              command:
-              - sh
-              - -c
-              - |
-                mkdir -p /agent-volume/usr/share/jenkins
-                cp /usr/share/jenkins/agent.jar /agent-volume/usr/share/jenkins/agent.jar
-                mkdir -p /workspace/agent
-              volumeMounts:
-              - name: agent-volume
-                mountPath: /agent-volume
-              - name: workspace-volume
-                mountPath: /workspace
-            containers:
-            - name: jnlp
-              image: quay.io/rhtap/tssc-jenkins-agent:latest
-              command:
-              - sh
-              - -c
-              - java -jar /usr/share/jenkins/agent.jar -url $JENKINS_URL -tunnel $JENKINS_TUNNEL -workDir /workspace/agent $JENKINS_SECRET $JENKINS_AGENT_NAME
-              env:
-              - name: JENKINS_URL
-                value: http://jenkins.jenkins.svc.cluster.local:8080/
-              - name: JENKINS_TUNNEL
-                value: jenkins-agent.jenkins.svc.cluster.local:50000
-              - name: _BUILDAH_STARTED_IN_USERNS
-                value: ""
-              - name: BUILDAH_ISOLATION
-                value: chroot
-              - name: STORAGE_DRIVER
-                value: vfs
-              imagePullPolicy: Always
-              resources:
-                requests:
-                  cpu: 100m
-                  memory: 256Mi
-                limits:
-                  cpu: 500m
-                  memory: 1Gi
-              workingDir: /workspace/agent
-              volumeMounts:
-              - name: workspace-volume
-                mountPath: /workspace
-              - name: agent-volume
-                mountPath: /usr/share/jenkins
-                subPath: usr/share/jenkins
-              - name: buildah-storage
-                mountPath: /home/jenkins/.local/share/containers
-            volumes:
-            - name: workspace-volume
-              emptyDir: {}
-            - name: agent-volume
-              emptyDir: {}
-            - name: buildah-storage
-              emptyDir: {}
+        agentInjection: true
+        containers:
+          - name: jnlp
+            image: quay.io/rhtap/tssc-jenkins-agent:latest
+            args: '$(JENKINS_SECRET) $(JENKINS_NAME)'
+            ttyEnabled: false
+            privileged: false
+            alwaysPullImage: true
+            resourceRequestCpu: "100m"
+            resourceRequestMemory: "256Mi"
+            resourceLimitCpu: "500m"
+            resourceLimitMemory: "1024Mi"
+            workingDir: "/home/jenkins/agent"
+            envVars:
+              - envVar:
+                  key: JENKINS_URL
+                  value: "http://jenkins.jenkins.svc.cluster.local:8080/"
+              - envVar:
+                  key: JENKINS_TUNNEL
+                  value: "jenkins-agent.jenkins.svc.cluster.local:50000"
+              - envVar:
+                  key: _BUILDAH_STARTED_IN_USERNS
+                  value: ""
+              - envVar:
+                  key: BUILDAH_ISOLATION
+                  value: "chroot"
+              - envVar:
+                  key: STORAGE_DRIVER
+                  value: "vfs"


### PR DESCRIPTION
Changes:
1. Remove admin password authentication in favor of  OpenShift OAuth integration for improved security and user management.
2. Update Jenkins version
3. Update agent Dockerfile to use the official Jenkins agent entrypoint script

Assisted-by: Claude