### PR TITLE
Add persistent volume sizes in Artifactory and Instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ kubectl -n rhacs-operator get secret central-htpasswd -o jsonpath='{.data.pass
 1. Trustification Integration may be found in tssc-tpa namespace.
    Secret - tssc-trustification-integration
 
-## Increase PVC size when App uses StatefulSets (Artifactory, Nexus) and controlled by Gitops
+## Increase PVC size when App uses StatefulSets with volumeClaimTemplates and controlled by Gitops
 
 1. Update Size in appropriate git file (Gitops sync will fail - "Forbidden: updates to statefulset spec..." Expected)
 
@@ -228,7 +228,7 @@ $ kubectl -n rhacs-operator get secret central-htpasswd -o jsonpath='{.data.pass
    * **BY UI:**
      - On confirmation screen make sure "Delete dependent objects of this resource" is not checked
 
-3. Manually patch the existing PVC (via UI or cli) to trigger the actual volume expansion. Wait for resize to complete
+3. (If not at correct size) Manually patch the existing PVC (via UI or cli) to trigger the actual volume expansion. Wait for resize to complete
 
    * **By CLI:**
      - Get PersistentVolumeClaims: ```$oc get pvc -n <NAMESPACE>```
@@ -236,7 +236,7 @@ $ kubectl -n rhacs-operator get secret central-htpasswd -o jsonpath='{.data.pass
    * **By UI:**
      - Goto PVC in Console and use "Expand PVC" action
 
-4. Force Sync to reconcile. Should be successful.
+4. Force Sync to reconcile. Sync should be successful.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -216,28 +216,6 @@ $ kubectl -n rhacs-operator get secret central-htpasswd -o jsonpath='{.data.pass
 1. Trustification Integration may be found in tssc-tpa namespace.
    Secret - tssc-trustification-integration
 
-## Increase PVC size when App uses StatefulSets with volumeClaimTemplates and controlled by Gitops
-
-1. Update Size in appropriate git file (Gitops sync will fail - "Forbidden: updates to statefulset spec..." Expected)
-
-2. Manually delete the existing StatefulSet using the --cascade=orphan option to remove the old immutable blueprint.
-
-   * **By CLI:**
-     - Get StatefulSets: ```$oc get sts -n <NAMESPACE>```
-     - Delete Appropriate StatefulSet: ```$oc delete sts <STATEFULSET_NAME> --cascade=orphan -n <NAMESPACE>```
-   * **BY UI:**
-     - On confirmation screen make sure "Delete dependent objects of this resource" is not checked
-
-3. (If not at correct size) Manually patch the existing PVC (via UI or cli) to trigger the actual volume expansion. Wait for resize to complete
-
-   * **By CLI:**
-     - Get PersistentVolumeClaims: ```$oc get pvc -n <NAMESPACE>```
-     - Patch Appropriate PVC to increase size: ```$oc patch pvc <PVC_NAME> -p '{"spec": {"resources": {"requests": {"storage": "NEW_SIZE_SET_IN_GIT_FILE>"}}}}' -n <NAMESPACE>```
-   * **By UI:**
-     - Goto PVC in Console and use "Expand PVC" action
-
-4. Force Sync to reconcile. Sync should be successful.
-
 ## Development
 
 ### Adding new component

--- a/README.md
+++ b/README.md
@@ -216,6 +216,28 @@ $ kubectl -n rhacs-operator get secret central-htpasswd -o jsonpath='{.data.pass
 1. Trustification Integration may be found in tssc-tpa namespace.
    Secret - tssc-trustification-integration
 
+## Increase PVC size when App uses StatefulSets (Artifactory, Nexus) and controlled by Gitops
+
+1. Update Size in appropriate git file (Gitops sync will fail - "Forbidden: updates to statefulset spec..." Expected)
+
+2. Manually delete the existing StatefulSet using the --cascade=orphan option to remove the old immutable blueprint.
+
+   * **By CLI:**
+     - Get StatefulSets: ```$oc get sts -n <NAMESPACE>```
+     - Delete Appropriate StatefulSet: ```$oc delete sts <STATEFULSET_NAME> --cascade=orphan -n <NAMESPACE>```
+   * **BY UI:**
+     - On confirmation screen make sure "Delete dependent objects of this resource" is not checked
+
+3. Manually patch the existing PVC (via UI or cli) to trigger the actual volume expansion. Wait for resize to complete
+
+   * **By CLI:**
+     - Get PersistentVolumeClaims: ```$oc get pvc -n <NAMESPACE>```
+     - Patch Appropriate PVC to increase size: ```$oc patch pvc <PVC_NAME> -p '{"spec": {"resources": {"requests": {"storage": "NEW_SIZE_SET_IN_GIT_FILE>"}}}}' -n <NAMESPACE>```
+   * **By UI:**
+     - Goto PVC in Console and use "Expand PVC" action
+
+4. Force Sync to reconcile. Should be successful.
+
 ## Development
 
 ### Adding new component

--- a/components/artifactory/kustomization.yaml
+++ b/components/artifactory/kustomization.yaml
@@ -4,3 +4,4 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 resources:
   - routes.yaml
+  - pvc.yaml

--- a/components/artifactory/pvc.yaml
+++ b/components/artifactory/pvc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: artifactory-volume-jfrog-container-registry-artifactory-0
+  namespace: artifactory
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-jfrog-container-registry-postgresql-0
+  namespace: artifactory
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+---
+

--- a/components/artifactory/values.yaml
+++ b/components/artifactory/values.yaml
@@ -8,7 +8,7 @@ artifactory:
   artifactory:
     persistence:
       enabled: true  # Ensure persistence is enabled (it is by default)
-      size: 500Gi
+      existingClaim: "artifactory-volume-jfrog-container-registry-artifactory-0"
     podSecurityContext:
       enabled: false
     containerSecurityContext:
@@ -36,7 +36,7 @@ artifactory:
     primary:
       persistence:
         enabled: true
-        size: 200Gi
+        existingClaim: "data-jfrog-container-registry-postgresql-0"
       podSecurityContext:
         enabled: false
       securityContext:

--- a/components/artifactory/values.yaml
+++ b/components/artifactory/values.yaml
@@ -6,6 +6,9 @@ artifactory:
     enabled: false
 
   artifactory:
+    persistence:
+      enabled: true  # Ensure persistence is enabled (it is by default)
+      size: 500Gi
     podSecurityContext:
       enabled: false
     containerSecurityContext:
@@ -31,6 +34,9 @@ artifactory:
     auth:
       password: "a-strong-password"
     primary:
+      persistence:
+        enabled: true
+        size: 200Gi
       podSecurityContext:
         enabled: false
       securityContext:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for resizing PVCs via GitOps (note: the guide appears twice in the README).

* **New Features**
  * Added persistent storage for Artifactory (500 GiB) and PostgreSQL (200 GiB) and registered the PVCs with the deployment manifests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->