### PR TITLE
Increase tpa-pgsql-bee memory limits to fix OOMKills

### DIFF
--- a/components/trust-apps/tpa/infrastructure.yaml
+++ b/components/trust-apps/tpa/infrastructure.yaml
@@ -79,11 +79,11 @@ spec:
             - containerPort: 5432
           resources:
             limits:
-              cpu: "1"
-              memory: 1Gi
+              cpu: "2"
+              memory: 4Gi
             requests:
-              cpu: 250m
-              memory: 512Mi
+              cpu: 500m
+              memory: 2Gi
           readinessProbe:
             tcpSocket:
               port: 5432


### PR DESCRIPTION
The PostgreSQL pod (tpa-pgsql-bee) is repeatedly OOM-killed because the 25GB database with 50 concurrent connections consistently uses 900-980MB, exceeding the 1Gi limit. This causes SBOM upload failures with "Connection pool timed out" errors.

Increase memory limit from 1Gi to 4Gi and request from 512Mi to 2Gi. Also bump CPU limit/request slightly as observed usage (350m) was already above the old 250m request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database infrastructure resource allocation to improve system performance and reliability during peak usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->